### PR TITLE
Concurrent + lock free iteration

### DIFF
--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
@@ -174,6 +174,10 @@ public class KTypeVTypeHashMap<KType, VType>
     this(DEFAULT_EXPECTED_ELEMENTS, DEFAULT_LOAD_FACTOR, concurrent);
   }
 
+  public boolean isConcurrent() {
+    return concurrent;
+  }
+
   /**
    * Create a hash map from all key-value pairs of another container.
    */

--- a/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
+++ b/hppc/src/main/templates/com/carrotsearch/hppc/KTypeVTypeHashMap.java
@@ -13,6 +13,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.carrotsearch.hppc.Containers.DEFAULT_EXPECTED_ELEMENTS;
 import static com.carrotsearch.hppc.HashContainers.*;
+import static com.carrotsearch.hppc.Containers.*;
 
 /**
  * A hash map of <code>KType</code> to <code>VType</code>, implemented using open

--- a/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeConcurrentHashMapTest.java
+++ b/hppc/src/test/templates/com/carrotsearch/hppc/KTypeVTypeConcurrentHashMapTest.java
@@ -1,0 +1,14 @@
+/*! #set($TemplateOptions.ignored = ($TemplateOptions.isKTypeAnyOf("DOUBLE", "FLOAT", "BYTE"))) !*/
+package com.carrotsearch.hppc;
+
+/**
+ * Same tests as those in {@link KTypeVTypeHashMap}, but with {@link KTypeVTypeHashMap#concurrent} set to true.
+ */
+/*! ${TemplateOptions.generatedAnnotation} !*/
+public class KTypeVTypeConcurrentHashMapTest<KType, VType> extends KTypeVTypeHashMapTest<KType, VType> {
+
+  @Override
+  protected KTypeVTypeHashMap<KType, VType> newInstance() {
+    return new KTypeVTypeHashMap<>(true);
+  }
+}


### PR DESCRIPTION
In order to guarantee thread safety and a lock free iteration,
the following needs to be considered:
<ol>
  <li>Do not invoke any form of key removal, such as {#remove(Object)},
  {#removeAll(KTypeContainer)}, etc. Doing so, might invoke
  {#shiftConflictingKeys(int)}, which will result in an inconsistent
  iteration (if ongoing). One trick is to put in a sentinel value,
  and handle that in your application code.</li>
  <li>If an add operation results in an rehash operation, any ongoing
  iterations will reflect the entries just before the rehashing operation started
  (snapshot iterator).</li>
</ol>
<p>
How thread safety is implemented:
<ol>
  <li>Modifications take a write lock from {#lock}</li>
  <li>Retrievals take a read lock from {#lock}</li>
  <li>When an iteration is requested, references to the following are captured
  using a write lock (to prevent rehashing to occur at this exact moment):
  <ol>
    <li>{#keys}</li>
    <li>{#values}</li>
    <li>{#mask}</li>
  </ol>
  See {StateSnapshot} for more details. After a snapshot is captured,
  the iteration continues lock free.
  </li>
  <li>During a rehashing event, all access to the map is blocked,
  including requests for new iterations</li>
</ol>